### PR TITLE
Use tini as entrypoint in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM python:3.12.5-slim-bullseye
 
-RUN pip3 install gunicorn
+RUN apt update -qq && \
+    apt install --yes tini && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install gunicorn
 
 RUN mkdir /opt/frx-challenges
+
+COPY requirements.txt /tmp/requirements.txt
+RUN python -m pip install -r /tmp/requirements.txt
 
 COPY . /opt/frx-challenges
 
 WORKDIR /opt/frx-challenges/frx_challenges
 
-RUN pip3 install -r ../requirements.txt
+ENTRYPOINT ["tini", "--"]

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
         - name: django
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
+          args:
             - gunicorn
             - --bind
             - 127.0.0.1:8000
@@ -124,7 +124,7 @@ spec:
         - name: evaluator
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
+          args:
             - python
             - manage.py
             - evaluator


### PR DESCRIPTION
This makes sure that the pod terminates immediately, by having the SIGTERM handlers be handled correctly (see pt 2 of https://github.com/krallin/tini?tab=readme-ov-file#why-tini). Without this, the pod can be in 'terminating' state for upto 30s, so deployments take much longer than they should. See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination for more information.

Additionally:
- Make image building slightly more efficient, by not copying entire contents of the image each time. Only requirements.txt is copied directly first, so cache busting is less frequent.
- Use python -m pip rather than the deprecated pip3 alias