### PR TITLE
Show list of versions + evaluations in the submission detail page

### DIFF
--- a/frx_challenges/frx_challenges/settings.py
+++ b/frx_challenges/frx_challenges/settings.py
@@ -261,10 +261,16 @@ SITE_SUBMISSION_FORM_SCHEMA = {
     },
 }
 
-EVALUATION_DISPLAY_CONFIG = {
-    "chars": {"display_name": "Characters"},
-    "lines": {"display_name": "Lines"},
-}
+EVALUATION_DISPLAY_CONFIG = [
+    {
+        "result_key": "chars",
+        "display_name": "Characters"
+    },
+    {
+        "result_key": "lines",
+        "display_name": "Lines"
+    }
+]
 
 django_yamlconf.load()
 django_yamlconf.list_attrs()

--- a/frx_challenges/frx_challenges/settings.py
+++ b/frx_challenges/frx_challenges/settings.py
@@ -262,14 +262,8 @@ SITE_SUBMISSION_FORM_SCHEMA = {
 }
 
 EVALUATION_DISPLAY_CONFIG = [
-    {
-        "result_key": "chars",
-        "display_name": "Characters"
-    },
-    {
-        "result_key": "lines",
-        "display_name": "Lines"
-    }
+    {"result_key": "chars", "display_name": "Characters"},
+    {"result_key": "lines", "display_name": "Lines"},
 ]
 
 django_yamlconf.load()

--- a/frx_challenges/web/context_processors.py
+++ b/frx_challenges/web/context_processors.py
@@ -15,4 +15,5 @@ def site_display_settings(request):
         "site_footer_html": settings.SITE_FOOTER_HTML,
         "site_page_header_image_url": settings.SITE_PAGE_HEADER_IMAGE_URL,
         "challenge_state": settings.CHALLENGE_STATE,
+        "evaluation_display_config": settings.EVALUATION_DISPLAY_CONFIG
     }

--- a/frx_challenges/web/context_processors.py
+++ b/frx_challenges/web/context_processors.py
@@ -15,5 +15,5 @@ def site_display_settings(request):
         "site_footer_html": settings.SITE_FOOTER_HTML,
         "site_page_header_image_url": settings.SITE_PAGE_HEADER_IMAGE_URL,
         "challenge_state": settings.CHALLENGE_STATE,
-        "evaluation_display_config": settings.EVALUATION_DISPLAY_CONFIG
+        "evaluation_display_config": settings.EVALUATION_DISPLAY_CONFIG,
     }

--- a/frx_challenges/web/management/commands/evaluator.py
+++ b/frx_challenges/web/management/commands/evaluator.py
@@ -167,15 +167,6 @@ class Command(BaseCommand):
     async def ahandle(self):
         evaluator = DockerEvaluator()
         while True:
-            # Create evaluation objects when they do not exist
-            versions_without_evaluations = Version.objects.filter(
-                Q(status=Version.Status.UPLOADED),
-                ~Exists(Evaluation.objects.filter(version=OuterRef("pk"))),
-            )
-            async for v in versions_without_evaluations:
-                e = Evaluation(version=v)
-                await e.asave()
-
             # Get the Evaluations that have not been started yet
             unstarted_evaluations = Evaluation.objects.select_related("version").filter(
                 status=Evaluation.Status.NOT_STARTED

--- a/frx_challenges/web/management/commands/evaluator.py
+++ b/frx_challenges/web/management/commands/evaluator.py
@@ -10,9 +10,8 @@ import aiodocker.containers
 import fsspec
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db.models import Exists, OuterRef, Q
 
-from ...models import Evaluation, Version
+from ...models import Evaluation
 
 logger = logging.getLogger()
 

--- a/frx_challenges/web/models.py
+++ b/frx_challenges/web/models.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+
+from typing import List, Optional
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models, transaction
 from django_jsonform.models.fields import JSONField
-from typing import Optional, List
+
 # Create your models here.
 
 
@@ -60,15 +63,14 @@ class Version(models.Model):
     status = models.CharField(choices=Status, default=Status.NOT_STARTED, max_length=16)
 
     @property
-    def latest_evaluation(self) -> Optional[Evaluation]:
+    def latest_evaluation(self) -> Evaluation | None:
         """
         Return the latest Evaluation if it exists
         """
         try:
-            return self.evaluations.latest('last_updated')
+            return self.evaluations.latest("last_updated")
         except Evaluation.DoesNotExist:
             return None
-
 
     def __str__(self):
         return f"({self.status}) {self.data_uri}"
@@ -93,7 +95,7 @@ class Evaluation(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
 
     @property
-    def ordered_results(self) -> List:
+    def ordered_results(self) -> list:
         """
         Return results of this evaluation, ordered per EVALUATION_DISPLAY_CONFIG
         """

--- a/frx_challenges/web/models.py
+++ b/frx_challenges/web/models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models, transaction

--- a/frx_challenges/web/templates/results.html
+++ b/frx_challenges/web/templates/results.html
@@ -40,7 +40,7 @@
       const resp = await fetch("/results");
       const respData = await resp.json();
 
-      const config = respData["config"];
+      const displayConfig = respData["display_config"];
       const evaluations = respData["results"];
 
       const columns = [
@@ -56,12 +56,12 @@
           },
         },
       ].concat(
-        Object.keys(config).map((k) => {
+        displayConfig.map((dc) => {
           return {
-            title: config[k].display_name,
+            title: dc.display_name,
             data: (row) => {
-              if (row.result && k in row.result) {
-                return row.result[k];
+              if (row.result && dc.result_key in row.result) {
+                return row.result[dc.result_key];
               } else {
                 return "";
               }

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet"
           href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
     <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
-{% endblock %}
+{% endblock head %}
 {% block body %}
     <div class="container py-2">
         <div class="row py-2">
@@ -46,7 +46,8 @@
                                         {% if r %}{{ r }}{% endif %}
                                     </td>
                                 {% endfor %}
-                            {% endfor %}
+                            </tr>
+                        {% endfor %}
                         </tbody>
                     </table>
                 </div>

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -48,22 +48,22 @@
                                 {% endfor %}
                             </tr>
                         {% endfor %}
-                        </tbody>
-                    </table>
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="row py-2">
+                <div class="col">
+                    <a href="{% url 'upload' submission.id %}" class="btn btn-primary mt-2">Upload submission</a>
                 </div>
-            {% else %}
-                <div class="row py-2">
-                    <div class="col">
-                        <a href="{% url 'upload' submission.id %}" class="btn btn-primary mt-2">Upload submission</a>
-                    </div>
-                </div>
-            {% endif %}
-        </div>
-        <script>
+            </div>
+        {% endif %}
+    </div>
+    <script>
         async function main() {
             const resultsTable = new DataTable("#results");
         }
 
         main();
-        </script>
-    {% endblock body %}
+    </script>
+{% endblock body %}

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% block head %}
-<script src="https://code.jquery.com/jquery-3.7.1.min.js"
-integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
-crossorigin="anonymous"></script>
-<link rel="stylesheet"
-href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
-<script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+            crossorigin="anonymous"></script>
+    <link rel="stylesheet"
+          href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
+    <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
 {% endblock %}
 {% block body %}
     <div class="container py-2">
@@ -31,9 +31,7 @@ href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
                             <th scope="col">Filename</th>
                             <th scope="col">Date uploaded</th>
                             <th scope="col">Evaluation Status</th>
-                            {% for dc in evaluation_display_config %}
-                            <th scope="col">{{ dc.display_name }}</th>
-                            {% endfor %}
+                            {% for dc in evaluation_display_config %}<th scope="col">{{ dc.display_name }}</th>{% endfor %}
                         </tr>
                     </thead>
                     <tbody>
@@ -44,29 +42,27 @@ href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
                                 <td>{{ v.date_created|date:"M j Y" }}</td>
                                 <td>{{ v.latest_evaluation.status }}</td>
                                 {% for r in v.latest_evaluation.ordered_results %}
-                                <td scope="col">
-                                    {% if r %}
-                                    {{ r }}
-                                    {% endif %}
-                                </td>
+                                    <td scope="col">
+                                        {% if r %}{{ r }}{% endif %}
+                                    </td>
                                 {% endfor %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        {% else %}
-            <div class="row py-2">
-                <div class="col">
-                    <a href="{% url 'upload' submission.id %}" class="btn btn-primary mt-2">Upload submission</a>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        {% endif %}
-    </div>
-    <script>
+            {% else %}
+                <div class="row py-2">
+                    <div class="col">
+                        <a href="{% url 'upload' submission.id %}" class="btn btn-primary mt-2">Upload submission</a>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+        <script>
         async function main() {
             const resultsTable = new DataTable("#results");
         }
 
         main();
-    </script>
-{% endblock body %}
+        </script>
+    {% endblock body %}

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -1,4 +1,12 @@
 {% extends "page.html" %}
+{% block head %}
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"
+integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+crossorigin="anonymous"></script>
+<link rel="stylesheet"
+href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
+<script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
+{% endblock %}
 {% block body %}
     <div class="container py-2">
         <div class="row py-2">
@@ -16,13 +24,16 @@
                 </div>
             </div>
             <div class="row py-2">
-                <table class="table table-striped table-sm">
+                <table id="results" class="table table-striped table-sm">
                     <thead>
                         <tr>
                             <th scope="col">ID</th>
                             <th scope="col">Filename</th>
                             <th scope="col">Date uploaded</th>
-                            <th scope="col">Evaluation</th>
+                            <th scope="col">Evaluation Status</th>
+                            {% for dc in evaluation_display_config %}
+                            <th scope="col">{{ dc.display_name }}</th>
+                            {% endfor %}
                         </tr>
                     </thead>
                     <tbody>
@@ -31,14 +42,14 @@
                                 <td>{{ v.id }}</td>
                                 <td>{{ v.filename }}</td>
                                 <td>{{ v.date_created|date:"M j Y" }}</td>
-                                {% if v.evaluation_set.all %}
-                                    <td>
-                                        <a href="{% url 'evaluation-detail' v.evaluation_set.all.0.id %}">View score</a>
-                                    </td>
-                                {% else %}
-                                    <td>Pending</td>
-                                {% endif %}
-                            </tr>
+                                <td>{{ v.latest_evaluation.status }}</td>
+                                {% for r in v.latest_evaluation.ordered_results %}
+                                <td scope="col">
+                                    {% if r %}
+                                    {{ r }}
+                                    {% endif %}
+                                </td>
+                                {% endfor %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -51,4 +62,11 @@
             </div>
         {% endif %}
     </div>
+    <script>
+        async function main() {
+            const resultsTable = new DataTable("#results");
+        }
+
+        main();
+    </script>
 {% endblock body %}

--- a/frx_challenges/web/views/default.py
+++ b/frx_challenges/web/views/default.py
@@ -3,9 +3,9 @@ import tempfile
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
-from django.db import transaction
 from markdown_it import MarkdownIt
 from mdit_py_plugins.footnote import footnote_plugin
 from mdit_py_plugins.front_matter import front_matter_plugin
@@ -57,7 +57,10 @@ def upload(request: HttpRequest, id: int) -> HttpResponse:
 def results(request: HttpRequest) -> HttpResponse:
     evaluations = Evaluation.objects.all()
 
-    evaluations_resp = {"display_config": settings.EVALUATION_DISPLAY_CONFIG, "results": []}
+    evaluations_resp = {
+        "display_config": settings.EVALUATION_DISPLAY_CONFIG,
+        "results": [],
+    }
 
     for ev in evaluations:
         evaluations_resp["results"].append(


### PR DESCRIPTION
- Create initial evaluation along with version on upload, so we know that each version always has at least one evaluation added to it
- Turn the evaluation display config into a list, so ordering is preserved across multiple places it is displayed in
- Display the list of versions with their evaluation scores as a datatable so it can be sorted.

Fixes https://github.com/2i2c-org/frx-challenges/issues/159 
Ref https://github.com/2i2c-org/frx-challenges/issues/176