### PR TITLE
Implement a way to show details of a specific version

### DIFF
--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -64,7 +64,9 @@
                     <tbody>
                         {% for v in versions %}
                             <tr>
-                                <td><a href="{% url 'versions-view' v.id %}">{{ v.id }}</a></td>
+                                <td>
+                                    <a href="{% url 'versions-view' v.id %}">{{ v.id }}</a>
+                                </td>
                                 <td>{{ v.filename }}</td>
                                 <td>{{ v.date_created|date:"c" }}</td>
                                 <td>{{ v.latest_evaluation.status }}</td>

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -64,7 +64,7 @@
                     <tbody>
                         {% for v in versions %}
                             <tr>
-                                <td>{{ v.id }}</td>
+                                <td><a href="{% url 'versions-view' v.id %}">{{ v.id }}</a></td>
                                 <td>{{ v.filename }}</td>
                                 <td>{{ v.date_created|date:"c" }}</td>
                                 <td>{{ v.latest_evaluation.status }}</td>

--- a/frx_challenges/web/templates/version.html
+++ b/frx_challenges/web/templates/version.html
@@ -11,7 +11,7 @@
         Status: <strong>{{ evaluation.status }}</strong>
         {% if evaluation.status != "EVALUATED" and evaluation.status != "FAILED" %}
         <a href="#" onclick="window.location.reload(); return false;">
-            <img title="Check for updates" src="{% static 'web/arrow-repeat.svg' %}">
+            <img alt="Check for updates" src="{% static 'web/arrow-repeat.svg' %}">
         </a>
         {% endif %}
     </div>

--- a/frx_challenges/web/templates/version.html
+++ b/frx_challenges/web/templates/version.html
@@ -1,38 +1,36 @@
 {% extends "page.html" %}
 {% load static %}
 {% block body %}
-<div class="container py-2">
-<h2>Version {{ version.id }} for
-    <a href="{% url 'submissions-detail' version.submission.id %}">{{ version.submission.name }}</a>
-</h2>
-
-<div class="row">
-    <div class="col-sm-6">
-        Status: <strong>{{ evaluation.status }}</strong>
-        {% if evaluation.status != "EVALUATED" and evaluation.status != "FAILED" %}
-        <a href="#" onclick="window.location.reload(); return false;">
-            <img alt="Check for updates" src="{% static 'web/arrow-repeat.svg' %}">
-        </a>
-        {% endif %}
+    <div class="container py-2">
+        <h2>
+            Version {{ version.id }} for
+            <a href="{% url 'submissions-detail' version.submission.id %}">{{ version.submission.name }}</a>
+        </h2>
+        <div class="row">
+            <div class="col-sm-6">
+                Status: <strong>{{ evaluation.status }}</strong>
+                {% if evaluation.status != "EVALUATED" and evaluation.status != "FAILED" %}
+                    <a href="#" onclick="window.location.reload(); return false;">
+                        <img alt="Check for updates" src="{% static 'web/arrow-repeat.svg' %}">
+                    </a>
+                {% endif %}
+            </div>
+            <div class="col-sm-6 text-end">
+                {{ version.user.username }} uploaded <code>{{ version.filename }}</code> {{ version.date_created|timesince }} ago
+            </div>
+        </div>
+        <div class="row py-4">
+            <h4>Result</h4>
+            {% if evaluation.status == 'EVALUATED' %}
+                {% for result_item in results_display %}
+                    <div class="col">
+                        <strong class="d-inline">{{ result_item.display_name }}</strong>
+                        <p>{{ result_item.value }}</p>
+                    </div>
+                {% endfor %}
+            {% else %}
+                <div class="text-center">Evaluation results will be displayed here once completed</div>
+            {% endif %}
+        </div>
     </div>
-    <div class="col-sm-6 text-end">{{ version.user.username }} uploaded <code>{{ version.filename }}</code> {{ version.date_created|timesince }} ago</div>
-</div>
-
-<div class="row py-4">
-    <h4>Result</h4>
-    {% if evaluation.status == 'EVALUATED' %}
-    {% for result_item in results_display %}
-    <div class="col">
-        <strong class="d-inline">{{ result_item.display_name }}</strong>
-        <p>{{ result_item.value }}</p>
-    </div>
-    {% endfor %}
-    {% else %}
-    <div class="text-center">
-        Evaluation results will be displayed here once completed
-    </div>
-    {% endif %}
-
-</div>
-</div>
 {% endblock body %}

--- a/frx_challenges/web/templates/version.html
+++ b/frx_challenges/web/templates/version.html
@@ -1,0 +1,38 @@
+{% extends "page.html" %}
+{% load static %}
+{% block body %}
+<div class="container py-2">
+<h2>Version {{ version.id }} for
+    <a href="{% url 'submissions-detail' version.submission.id %}">{{ version.submission.name }}</a>
+</h2>
+
+<div class="row">
+    <div class="col-sm-6">
+        Status: <strong>{{ evaluation.status }}</strong>
+        {% if evaluation.status != "EVALUATED" and evaluation.status != "FAILED" %}
+        <a href="#" onclick="window.location.reload(); return false;" title="Check for updates">
+            <img src="{% static 'web/arrow-repeat.svg' %}">
+        </a>
+        {% endif %}
+    </div>
+    <div class="col-sm-6 text-end">{{ version.user.username }} uploaded <code>{{ version.filename }}</code> {{ version.date_created|timesince }} ago</div>
+</div>
+
+<div class="row py-4">
+    <h4>Result</h4>
+    {% if evaluation.status == 'EVALUATED' %}
+    {% for result_item in results_display %}
+    <div class="col">
+        <strong class="d-inline">{{ result_item.display_name }}</strong>
+        <p>{{ result_item.value }}</p>
+    </div>
+    {% endfor %}
+    {% else %}
+    <div class="text-center">
+        Evaluation results will be displayed here once completed
+    </div>
+    {% endif %}
+
+</div>
+</div>
+{% endblock body %}

--- a/frx_challenges/web/templates/version.html
+++ b/frx_challenges/web/templates/version.html
@@ -10,8 +10,8 @@
     <div class="col-sm-6">
         Status: <strong>{{ evaluation.status }}</strong>
         {% if evaluation.status != "EVALUATED" and evaluation.status != "FAILED" %}
-        <a href="#" onclick="window.location.reload(); return false;" title="Check for updates">
-            <img src="{% static 'web/arrow-repeat.svg' %}">
+        <a href="#" onclick="window.location.reload(); return false;">
+            <img title="Check for updates" src="{% static 'web/arrow-repeat.svg' %}">
         </a>
         {% endif %}
     </div>

--- a/frx_challenges/web/urls.py
+++ b/frx_challenges/web/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
-from .views import default, pages, submissions, teams
+from .views import default, pages, submissions, teams, versions
 
 urlpatterns = [
-    path("upload/<int:id>", default.upload, name="upload"),
+    path("upload/<int:id>", versions.upload, name="upload"),
     path("teams/list", teams.list, name="teams-list"),
     path("teams/create", teams.create, name="teams-create"),
     path("teams/<int:id>", teams.view, name="teams-view"),
@@ -20,6 +20,7 @@ urlpatterns = [
     path("submissions/create", submissions.create, name="submissions-create"),
     path("submissions/<int:id>", submissions.detail, name="submissions-detail"),
     path("submissions/<int:id>/edit", submissions.edit, name="submissions-edit"),
+    path("versions/<int:id>", versions.view, name="versions-view"),
     path(
         "evaluation/<int:id>", submissions.detail_evaluation, name="evaluation-detail"
     ),

--- a/frx_challenges/web/views/default.py
+++ b/frx_challenges/web/views/default.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 
 from ..models import Submission, Version
 

--- a/frx_challenges/web/views/default.py
+++ b/frx_challenges/web/views/default.py
@@ -1,51 +1,10 @@
-import os
-import tempfile
-
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 
-from ..forms import UploadForm
-from ..md import MARKDOWN_RENDERER
-from ..models import Evaluation, Submission, Version
+from ..models import Submission, Version
 
-
-@login_required
-def upload(request: HttpRequest, id: int) -> HttpResponse:
-    if request.method == "POST":
-        form = UploadForm(data=request.POST, files=request.FILES, id=id)
-        if form.is_valid():
-            # FIXME: We are creating the uploads directory on first use if
-            # necessary. This may be a security risk, let's verify.
-            os.makedirs(settings.SUBMISSIONS_UPLOADS_DIR, exist_ok=True)
-            _, filepath = tempfile.mkstemp(prefix=settings.SUBMISSIONS_UPLOADS_DIR)
-            with open(filepath, "wb") as f:
-                f.write(request.FILES["file"].read())
-            with transaction.atomic():
-                v = Version(
-                    submission=Submission.objects.get(id=id),
-                    user=request.user,
-                    status=Version.Status.UPLOADED,
-                    filename=request.FILES["file"].name,
-                    data_uri=f"file:///{filepath}",
-                )
-                v.save()
-
-                # Make sure every version has at least one evaluation
-                # by default, even if it has not been started
-                e = Evaluation(version=v)
-                e.save()
-            return redirect("submissions-detail", id)
-    else:
-        form = UploadForm(id=id)
-    html_content = MARKDOWN_RENDERER.render(
-        settings.SITE_SUBMISSION_INSTRUCTIONS_MARKDOWN
-    )
-    return render(
-        request, "upload.html", {"form": form, "id": id, "html_content": html_content}
-    )
 
 
 def leaderboard(request: HttpRequest) -> HttpResponse:

--- a/frx_challenges/web/views/default.py
+++ b/frx_challenges/web/views/default.py
@@ -5,7 +5,6 @@ from django.shortcuts import render
 from ..models import Submission, Version
 
 
-
 def leaderboard(request: HttpRequest) -> HttpResponse:
     if settings.CHALLENGE_STATE != "RUNNING":
         return HttpResponse(

--- a/frx_challenges/web/views/versions.py
+++ b/frx_challenges/web/views/versions.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from ..forms import UploadForm
+from ..md import MARKDOWN_RENDERER
+from ..models import Evaluation, Submission, Version
+
+@login_required
+def upload(request: HttpRequest, id: int) -> HttpResponse:
+    if request.method == "POST":
+        form = UploadForm(data=request.POST, files=request.FILES, id=id)
+        if form.is_valid():
+            # FIXME: We are creating the uploads directory on first use if
+            # necessary. This may be a security risk, let's verify.
+            os.makedirs(settings.SUBMISSIONS_UPLOADS_DIR, exist_ok=True)
+            _, filepath = tempfile.mkstemp(prefix=settings.SUBMISSIONS_UPLOADS_DIR)
+            with open(filepath, "wb") as f:
+                f.write(request.FILES["file"].read())
+            with transaction.atomic():
+                v = Version(
+                    submission=Submission.objects.get(id=id),
+                    user=request.user,
+                    status=Version.Status.UPLOADED,
+                    filename=request.FILES["file"].name,
+                    data_uri=f"file:///{filepath}",
+                )
+                v.save()
+
+                # Make sure every version has at least one evaluation
+                # by default, even if it has not been started
+                e = Evaluation(version=v)
+                e.save()
+            return redirect("versions-view", v.id)
+    else:
+        form = UploadForm(id=id)
+    html_content = MARKDOWN_RENDERER.render(
+        settings.SITE_SUBMISSION_INSTRUCTIONS_MARKDOWN
+    )
+    return render(
+        request, "upload.html", {"form": form, "id": id, "html_content": html_content}
+    )
+
+
+def view(request: HttpRequest, id: int) -> HttpResponse:
+    version = Version.objects.get(id=id)
+    evaluation = version.latest_evaluation
+
+    results_display = []
+    if evaluation.result:
+        for dc in settings.EVALUATION_DISPLAY_CONFIG:
+            results_display.append({
+                "display_name": dc["display_name"],
+                "value": evaluation.result.get(dc["result_key"])
+            })
+
+    return render(
+        request, "version.html", {"version": version, "evaluation": evaluation, "results_display": results_display}
+    )

--- a/frx_challenges/web/views/versions.py
+++ b/frx_challenges/web/views/versions.py
@@ -11,6 +11,7 @@ from ..forms import UploadForm
 from ..md import MARKDOWN_RENDERER
 from ..models import Evaluation, Submission, Version
 
+
 @login_required
 def upload(request: HttpRequest, id: int) -> HttpResponse:
     if request.method == "POST":
@@ -54,11 +55,19 @@ def view(request: HttpRequest, id: int) -> HttpResponse:
     results_display = []
     if evaluation.result:
         for dc in settings.EVALUATION_DISPLAY_CONFIG:
-            results_display.append({
-                "display_name": dc["display_name"],
-                "value": evaluation.result.get(dc["result_key"])
-            })
+            results_display.append(
+                {
+                    "display_name": dc["display_name"],
+                    "value": evaluation.result.get(dc["result_key"]),
+                }
+            )
 
     return render(
-        request, "version.html", {"version": version, "evaluation": evaluation, "results_display": results_display}
+        request,
+        "version.html",
+        {
+            "version": version,
+            "evaluation": evaluation,
+            "results_display": results_display,
+        },
     )


### PR DESCRIPTION
- Don't show *all* the results, as we don't know yet if that can be used to overfit a model to just meet the requirements
- Redirect to a version's detail page after upload
- User can click the refresh button to check for updates
- Link to version detail page from submissions page

Ref https://github.com/2i2c-org/frx-challenges/issues/189