### PR TITLE
Require specifying full path to evaluator command

### DIFF
--- a/frx_challenges/frx_challenges/settings.py
+++ b/frx_challenges/frx_challenges/settings.py
@@ -218,7 +218,10 @@ output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "outputs/")
 SUBMISSIONS_RESULTS_DIR = output_dir
 
 EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
-EVALUATOR_DOCKER_CMD = []
+# `{submission_path}` and `{result_path}` are substituted
+EVALUATOR_DOCKER_CMD = [
+    "{submission_path}", "{result_path}"
+]
 
 # Set to true to disable network access from inside the container started by evaluator
 EVALUATOR_DOCKER_DISABLE_NETWORK = True

--- a/frx_challenges/frx_challenges/settings.py
+++ b/frx_challenges/frx_challenges/settings.py
@@ -219,9 +219,7 @@ SUBMISSIONS_RESULTS_DIR = output_dir
 
 EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
 # `{submission_path}` and `{result_path}` are substituted
-EVALUATOR_DOCKER_CMD = [
-    "{submission_path}", "{result_path}"
-]
+EVALUATOR_DOCKER_CMD = ["{submission_path}", "{result_path}"]
 
 # Set to true to disable network access from inside the container started by evaluator
 EVALUATOR_DOCKER_DISABLE_NETWORK = True

--- a/frx_challenges/web/management/commands/evaluator.py
+++ b/frx_challenges/web/management/commands/evaluator.py
@@ -73,14 +73,14 @@ class DockerEvaluator:
             host_config["Memory"] = settings.EVALUATOR_DOCKER_CONTAINER_MEMORY_LIMIT
         if settings.EVALUATOR_DOCKER_DISABLE_NETWORK:
             host_config["NetworkMode"] = "none"
+        cmd = [c.format(
+            submission_path=input_container_path,
+            result_path=f'{output_container_path}/output.json'
+        ) for c in settings.EVALUATOR_DOCKER_CMD]
         container = await self.docker.containers.create(
             config={
                 "Image": self.image,
-                "Cmd": settings.EVALUATOR_DOCKER_CMD
-                + [
-                    f"{input_container_path}",
-                    f"{output_container_path}/output.json",
-                ],
+                "Cmd": cmd,
                 "HostConfig": host_config,
             }
         )

--- a/frx_challenges/web/management/commands/evaluator.py
+++ b/frx_challenges/web/management/commands/evaluator.py
@@ -73,10 +73,13 @@ class DockerEvaluator:
             host_config["Memory"] = settings.EVALUATOR_DOCKER_CONTAINER_MEMORY_LIMIT
         if settings.EVALUATOR_DOCKER_DISABLE_NETWORK:
             host_config["NetworkMode"] = "none"
-        cmd = [c.format(
-            submission_path=input_container_path,
-            result_path=f'{output_container_path}/output.json'
-        ) for c in settings.EVALUATOR_DOCKER_CMD]
+        cmd = [
+            c.format(
+                submission_path=input_container_path,
+                result_path=f"{output_container_path}/output.json",
+            )
+            for c in settings.EVALUATOR_DOCKER_CMD
+        ]
         container = await self.docker.containers.create(
             config={
                 "Image": self.image,
@@ -97,7 +100,7 @@ class DockerEvaluator:
             "container_id": container.id,
             "results_uri": results_uri,
             "command": cmd,
-            "image": self.image
+            "image": self.image,
         }
 
     async def is_still_running(self, state: dict) -> bool:

--- a/frx_challenges/web/management/commands/evaluator.py
+++ b/frx_challenges/web/management/commands/evaluator.py
@@ -96,6 +96,8 @@ class DockerEvaluator:
         return {
             "container_id": container.id,
             "results_uri": results_uri,
+            "command": cmd,
+            "image": self.image
         }
 
     async def is_still_running(self, state: dict) -> bool:


### PR DESCRIPTION
Previously, we were always appending the path to the submitted file and the path to the results file. This prevented use of evaluation commands that required specifying these paths as named parameters instead of unnamed arguments.