### PR TITLE
Make lists *actually* show in reverse chronological order

### DIFF
--- a/frx_challenges/web/templates/results.html
+++ b/frx_challenges/web/templates/results.html
@@ -62,7 +62,7 @@
           const resultsTable = new DataTable("#results", {
               order: [
                   // Apply reverse chronological ordering by default
-                  [3, "asc"]
+                  [3, "desc"]
               ],
               columnDefs: [
                   {

--- a/frx_challenges/web/templates/submission/detail.html
+++ b/frx_challenges/web/templates/submission/detail.html
@@ -98,7 +98,7 @@
             const resultsTable = new DataTable("#results", {
                 order: [
                     // Apply reverse chronological ordering by default
-                    [2, "asc"]
+                    [2, "desc"]
                 ],
                 columnDefs: [
                     {

--- a/frx_challenges/web/templates/submission/list.html
+++ b/frx_challenges/web/templates/submission/list.html
@@ -69,7 +69,7 @@
         const resultsTable = new DataTable("#results", {
             order: [
                 // Apply reverse chronological ordering by default
-                [3, "asc"]
+                [3, "desc"]
             ],
             columnDefs: [
                 {


### PR DESCRIPTION
They were showing up in chronological order otherwise. We want latest to be first.

Ref https://github.com/2i2c-org/frx-challenges/issues/190