### PR TITLE
Revert "Provide more useful str representations for models"

### DIFF
--- a/frx_challenges/web/models.py
+++ b/frx_challenges/web/models.py
@@ -24,9 +24,6 @@ class Submission(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
 
-    def __str__(self):
-        return f"name:{self.name} user:{self.user.username}"
-
     @property
     def best_version(self) -> Version:
         """
@@ -111,7 +108,7 @@ class Version(models.Model):
             return None
 
     def __str__(self):
-        return f"file:{self.filename} submission:{self.submission.name} user:{self.user.username}"
+        return f"({self.status}) {self.data_uri}"
 
 
 class Evaluation(models.Model):
@@ -148,7 +145,7 @@ class Evaluation(models.Model):
         return results_list
 
     def __str__(self):
-        return f"submission:{self.version.submission.name} version:{self.version.id} id:{self.id} status:{self.status}"
+        return f"({self.status}) {self.result} {self.version.data_uri}"
 
 
 class Collaborator(models.Model):
@@ -159,9 +156,6 @@ class Collaborator(models.Model):
     is_owner = models.BooleanField()
     submission = models.ForeignKey(Submission, on_delete=models.CASCADE)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-
-    def __str__(self):
-        return f"submission:{self.submission.name} user:{self.user.username}"
 
     class Meta:
         # A user can be added as a collaborator only once


### PR DESCRIPTION
Reverts 2i2c-org/frx-challenges#205

Causes evaluations to fail with:

```
Traceback (most recent call last):
  File "/opt/frx-challenges/frx_challenges/manage.py", line 22, in <module>
    main()
  File "/opt/frx-challenges/frx_challenges/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/frx-challenges/frx_challenges/web/management/commands/evaluator.py", line 219, in handle
    asyncio.run(self.ahandle())
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/frx-challenges/frx_challenges/web/management/commands/evaluator.py", line 214, in ahandle
    await self.process_running_evaluation(evaluator, e)
  File "/opt/frx-challenges/frx_challenges/web/management/commands/evaluator.py", line 170, in process_running_evaluation
    logger.info(f"{evaluation} is completed")
                  ^^^^^^^^^^^^
  File "/opt/frx-challenges/frx_challenges/web/models.py", line 151, in __str__
    return f"submission:{self.version.submission.name} version:{self.version.id} id:{self.id} status:{self.status}"
                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/fields/related_descriptors.py", line 257, in __get__
    rel_obj = self.get_object(instance)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/fields/related_descriptors.py", line 220, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 645, in get
    num = len(clone)
          ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 382, in __len__
    self._fetch_all()
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1572, in execute_sql
    cursor = self.connection.cursor()
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/asyncio.py", line 24, in inner
    raise SynchronousOnlyOperation(message)
django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f6634aa9af0>, 1616293.848390642)])']
connector: <aiohttp.connector.TCPConnector object at 0x7f6634a60d40>

```