### PR TITLE
Put dind on persistent storage as well

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: /opt/state
+            - name: dind-storage
+              mountPath: /var/lib/docker
           securityContext:
             privileged: true
             runAsUser: 0
@@ -160,6 +162,9 @@ spec:
         - name: storage
           persistentVolumeClaim:
             claimName: {{ include "frx-challenges.fullname" . }}
+        - name: dind-storage
+          persistentVolumeClaim:
+            claimName: {{ include "frx-challenges.fullname" . }}-dind
         - name: staticfiles
           emptyDir: {}
         - name: django-yamlconf

--- a/helm-chart/templates/pvc.yaml
+++ b/helm-chart/templates/pvc.yaml
@@ -13,3 +13,20 @@ spec:
   resources:
     requests:
       storage: {{ .Values.pvc.storage }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "frx-challenges.fullname" . }}-dind
+  labels:
+    {{- include "frx-challenges.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dind
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if typeIs "string" .Values.dind.pvc.storageClassName }}
+  storageClassName: {{ .Values.dind.pvc.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.dind.pvc.storage }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -73,3 +73,6 @@ dind:
   image:
     repository: docker
     tag: 27.0.3-dind
+  pvc:
+    storagerClassName: ""
+    storage: 100Gi


### PR DESCRIPTION
Without this, docker logs are wiped after each deploy, making debugging difficult